### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ e19f3b87dbf3`
 - port 800 on the docker container will talk to port 4000 on the server.
 - I 'bind' a mounted drive on the server to a drive on the docker container. This is needed so I can SSH into the server with my windows VDI and develop in VS Code!
 - Image e19f3b87dbf3 is pytorch image that I pulled from Docker Hub
+- It is important to note that use of the `--rm` flag will destroy the container upon exit. Any state that one would like persisted after the container exits should accommodate accordingly. 
 
 The container has Ubuntu OS 16.04 so remember to use Debian commands!
 


### PR DESCRIPTION
Updated Readme to explicitly call out the docker `--rm` flag which will destroy the container after exiting to prevent users from losing data.